### PR TITLE
Rename install to git-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Or you can obtain a binary from https://github.com/uw-labs/strongbox/releases
 
 ## Usage
 
- 1. As a one time action, install the plugin by running `strongbox install`. This will edit global git config to enable strongbox filter and diff configuration.
+ 1. As a one time action, configure the plugin by running `strongbox git-config`. This will edit global git config to enable strongbox filter and diff configuration.
 
  1. In each repository you want to use strongbox, create `.gitattributes` file containing the patterns to be managed by strongbox.
 

--- a/int_tests/sb_int_test.go
+++ b/int_tests/sb_int_test.go
@@ -62,7 +62,7 @@ func keyIdFromKR(t *testing.T, name string) (keyId string) {
 }
 
 func TestMain(m *testing.M) {
-	setUpCommand("/", "strongbox", "install")
+	setUpCommand("/", "strongbox", "git-config")
 	setUpCommand("/", "strongbox", "gen-key", "test00")
 	setUpCommand("/", "git", "config", "--global", "user.email", "\"you@example.com\"")
 	setUpCommand("/", "git", "config", "--global", "user.name", "\"test\"")

--- a/strongbox.go
+++ b/strongbox.go
@@ -46,9 +46,9 @@ func init() {
 
 func main() {
 	app := cli.App("strongbox", "Frictionless encryption workflow for git users")
-	app.Command("install", "configure git for strongbox use", func(cmd *cli.Cmd) {
+	app.Command("git-config", "configure git for strongbox use", func(cmd *cli.Cmd) {
 		cmd.Action = func() {
-			install()
+			gitConfig()
 		}
 	})
 	app.Command("gen-key", "Generate a new key and add it to your strongbox keyring", func(cmd *cli.Cmd) {
@@ -90,7 +90,7 @@ func main() {
 	}
 }
 
-func install() {
+func gitConfig() {
 	args := [][]string{
 		{"config", "--global", "--replace-all", "filter.strongbox.clean", "strongbox clean %f"},
 		{"config", "--global", "--replace-all", "filter.strongbox.smudge", "strongbox smudge %f"},


### PR DESCRIPTION
Rename 'install' command to 'git-config' to clarify purpose and align with implementation.