### PR TITLE
Expose application version in the binary via flags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 # Build customization
 builds:
-  - ldflags: -s -extldflags "-static"
+  - ldflags: -s -extldflags "-static" -X "main.version=git-tag:`{{.Env.CIRCLE_TAG}}`, git-sha1=`{{.Env.CIRCLE_SHA1}}`"
     env:
       - CGO_ENABLED=0
 

--- a/strongbox.go
+++ b/strongbox.go
@@ -37,12 +37,16 @@ var (
 	flagClean     = flag.String("clean", "", "intended to be called internally by git")
 	flagSmudge    = flag.String("smudge", "", "intended to be called internally by git")
 	flagDiff      = flag.String("diff", "", "intended to be called internally by git")
+	flagVersion   = flag.Bool("version", false, "Strongbox version")
+
+	version = ""
 )
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage:\n\n")
 	fmt.Fprintf(os.Stderr, "\tstrongbox -git-config\n")
 	fmt.Fprintf(os.Stderr, "\tstrongbox -gen-key key-name\n")
+	fmt.Fprintf(os.Stderr, "\tstrongbox -version\n")
 	os.Exit(2)
 }
 
@@ -68,6 +72,11 @@ func main() {
 	}
 
 	kr = &fileKeyRing{fileName: filepath.Join(home, ".strongbox_keyring")}
+
+	if *flagVersion || (flag.NArg() == 1 && flag.Arg(0) == "version") {
+		fmt.Println(version)
+		return
+	}
 
 	// only a single flag has been set
 	if flag.NFlag() != 1 {


### PR DESCRIPTION
`-version` or `version` argument will display the git tag (if present)
and the sha1 sum of the commit from which the binary was built

Closes https://github.com/uw-labs/strongbox/issues/24