### PR TITLE
Rich header

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 # Build customization
 builds:
-  - ldflags: -s -extldflags "-static" -X "main.version=git-tag:`{{.Env.CIRCLE_TAG}}`, git-sha1=`{{.Env.CIRCLE_SHA1}}`"
+  - ldflags: -s -extldflags "-static" -X "main.version={{.Env.CIRCLE_TAG}}"
     env:
       - CGO_ENABLED=0
 

--- a/strongbox_test.go
+++ b/strongbox_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"testing"
 
@@ -10,8 +12,8 @@ import (
 )
 
 var (
-	priv  []byte
-	plain = []byte("hello world. this is some plain text for testing")
+	priv, pub []byte
+	plain     = []byte("hello world. this is some plain text for testing")
 )
 
 func TestMain(m *testing.M) {
@@ -22,13 +24,16 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	keyID := sha256.Sum256(priv)
+	pub = keyID[:]
+
 	keyLoader = testKeyLoader
 
 	os.Exit(m.Run())
 }
 
-func testKeyLoader(string) ([]byte, error) {
-	return priv, nil
+func testKeyLoader(string) ([]byte, []byte, error) {
+	return priv, pub, nil
 }
 
 func TestMultipleClean(t *testing.T) {
@@ -39,6 +44,10 @@ func TestMultipleClean(t *testing.T) {
 
 	var doubleCleaned bytes.Buffer
 	clean(bytes.NewReader(cleaned.Bytes()), &doubleCleaned, "")
+
+	if testing.Verbose() {
+		fmt.Printf("%s", string(cleaned.Bytes()))
+	}
 
 	assert.Equal(string(cleaned.Bytes()), string(doubleCleaned.Bytes()))
 }


### PR DESCRIPTION
Can't decide if its better to split the header over several lines and introduce more complex header parsing. This is what an encrypted resource looks like:

```
# STRONGBOX ENCRYPTED RESOURCE ; See https://github.com/uw-labs/strongbox ; strongbox-version:  ; key-id: lxRxvdlLfQElMVqZzihauUSk4Xpd9khSilBZ0hTMOug=
v2vR0QzIWhoqL3vTIGNBlnWNezkbh6g/fp12Gi5IyZlT2N0xfEDDO++5eSbyjq3OarC9J6mJmzKI
OaYfIJrbCjjrqnDCTMogZkaDtNa+882zeMUmeTA=
```

Closes https://github.com/uw-labs/strongbox/issues/26