### PR TITLE
Command line UX improvements

### DIFF
--- a/integration_tests/main_test.go
+++ b/integration_tests/main_test.go
@@ -71,12 +71,12 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "%v", string(out))
 		os.Exit(1)
 	}
-	out, err = command("/", "strongbox", "-git-config")
+	out, err = command("/", "strongbox", "git-config")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", string(out))
 		os.Exit(1)
 	}
-	out, err = command("/", "strongbox", "-gen-key", "test00")
+	out, err = command("/", "strongbox", "gen-key", "test00")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", string(out))
 		os.Exit(1)
@@ -137,7 +137,7 @@ func TestMissingKey(t *testing.T) {
 	// remove the key for encryption
 	assertCommand(t, "/", "mv", HOME+"/.strongbox_keyring", HOME+"/.strongbox_keyring.bkup")
 
-	assertCommand(t, "/", "strongbox", "-gen-key", "tmp")
+	assertCommand(t, "/", "strongbox", "gen-key", "tmp")
 
 	assertWriteFile(t, repoDir+"/secrets/sec-missing-key", []byte(secVal), 0644)
 	_, err := command(repoDir, "git", "add", ".")


### PR DESCRIPTION
After needing to dig into the code to actually understand what some of the flags did - and also getting confused about what flags were meant to be used in combination with each other, I figured a little refactor would improve the user experience:

- implemented github.com/urfave/cli as a command line library
- changed what were originally flags to commands so there's a better distinguishment between command actions and options for commands
- now supports `--help` with full automatically generated documentation