### PR TITLE
Revert to v1 header prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ Compare an entire branch (as it would appear on the remote) to master:
 git diff-index -p master
 ```
 
-### Empty diff due to header metadata
-
-Version 0.3.1 adds key-id metadata to the header. Modifying the header but not
-the plain-text will result in "empty diff". You can see the changes to the
-header only using this command: `git diff-index HEAD -p`
-
 ## Key rotation
 
 To rotate keys, update the `.strongbox-keyid` with the new key id, then `touch`
@@ -110,6 +104,8 @@ deterministic encryption.
 
 ## Testing
 
-Run integration tests
+Run integration tests:
 
-    $ make test
+```
+make test
+```

--- a/strongbox.go
+++ b/strongbox.go
@@ -28,7 +28,7 @@ var (
 	keyLoader     = keyPair
 	kr            keyRing
 	prefix        = []byte("# STRONGBOX ENCRYPTED RESOURCE ;")
-	defaultPrefix = "# STRONGBOX ENCRYPTED RESOURCE ; See https://github.com/uw-labs/strongbox\n# key-id: %s\n"
+	defaultPrefix = []byte("# STRONGBOX ENCRYPTED RESOURCE ; See https://github.com/uw-labs/strongbox\n")
 
 	// Match lines *not* starting with `#`
 	// this should match ciphertext without the strongbox prefix
@@ -91,7 +91,7 @@ func main() {
 
 	if *flagDecrypt {
 		if *flagKey == "" {
-			log.Fatalf("Must provide a key when using -decrypt")
+			log.Fatalf("Must provide a `-key` when using -decrypt")
 		}
 		decryptCLI()
 		return
@@ -310,9 +310,7 @@ func encrypt(b []byte, key, keyID []byte) ([]byte, error) {
 		return nil, err
 	}
 	var buf []byte
-	p := fmt.Sprintf(defaultPrefix, encode(keyID))
-	buf = append(buf, []byte(p)...)
-
+	buf = append(buf, defaultPrefix...)
 	b64 := encode(out)
 	for len(b64) > 0 {
 		l := 76


### PR DESCRIPTION
Found issues with upgrading v1 to v2 prefix. If the prefix is upgraded
on the branch, the file still shows up "modified" on the local copy and
we are unable to merge.

Need to investigate alternative deployment methods, like having a
different filter for v2 prefix decoration
