### PR TITLE
Clean up code from the work on extended header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,28 @@ It supports use of different keys per directory if wanted. It can cover as many
 or as few files as you wish based on
 [.gitattributes](https://www.git-scm.com/docs/gitattributes)
 
+
+<!-- vim-markdown-toc GFM -->
+
+* [Installation](#installation)
+* [Usage](#usage)
+* [Existing project](#existing-project)
+* [Verification](#verification)
+* [Key rotation](#key-rotation)
+* [Security](#security)
+* [Testing](#testing)
+* [Known issues](#known-issues)
+	* [Clone file ordering](#clone-file-ordering)
+		* [Workaround](#workaround)
+
+<!-- vim-markdown-toc -->
+
 ## Installation
 
 You can obtain a binary from https://github.com/uw-labs/strongbox/releases
 
 Alternatively, assuming you have a working [Go](https://golang.org) installation, you can
 install via `go get github.com/uw-labs/strongbox`
-
-Since the binary version is now included in the strongbox file header, you are
-recommended using a release version.
 
 ## Usage
 
@@ -111,3 +124,21 @@ Run integration tests:
 ```
 make test
 ```
+
+## Known issues
+
+### Clone file ordering
+
+Given a `.strongbox-keyid` in the root of the repository and an encrypted file
+in the same directory,*and* alphabetically it comes before the key-id file.
+
+Git checks out files alphanumerically, so if the strongboxed file is being
+checked out before the `.strongbox-keyid` is present on disk, strongbox will
+fail to find the decryption key.
+
+Order of files being cloned is dictated by the index.
+
+#### Workaround
+
+Clone repository, let the descryption fail. Delete encrypted files and do `git
+checkout` on the deleted files.

--- a/strongbox.go
+++ b/strongbox.go
@@ -16,28 +16,20 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/jacobsa/crypto/siv"
 )
 
-const version = "v0.4.0-dev"
+const version = "dev"
 
 var (
-	keyLoader     = keyPair
+	keyLoader     = key
 	kr            keyRing
 	prefix        = []byte("# STRONGBOX ENCRYPTED RESOURCE ;")
 	defaultPrefix = []byte("# STRONGBOX ENCRYPTED RESOURCE ; See https://github.com/uw-labs/strongbox\n")
 
-	// Match lines *not* starting with `#`
-	// this should match ciphertext without the strongbox prefix
-	prefixStripRegex = regexp.MustCompile(`(?m)^[^#]+$`)
-
-	keyIDRegex = regexp.MustCompile(`key-id: (\w+)`)
-
-	errKeyNotFound            = errors.New("key not found")
-	errKeyIDMissingFromHeader = errors.New("strongbox header doesn't contain key-id")
+	errKeyNotFound = errors.New("key not found")
 
 	// flags
 	flagGitConfig = flag.Bool("git-config", false, "Configure git for strongbox use")
@@ -69,11 +61,6 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	// Set up keyring file name
-	home := deriveHome()
-
-	kr = &fileKeyRing{fileName: filepath.Join(home, ".strongbox_keyring")}
-
 	if *flagVersion || (flag.NArg() == 1 && flag.Arg(0) == "version") {
 		fmt.Println(version)
 		return
@@ -83,6 +70,15 @@ func main() {
 		gitConfig()
 		return
 	}
+
+	if *flagDiff != "" {
+		diff(*flagDiff)
+		return
+	}
+
+	// Set up keyring file name
+	home := deriveHome()
+	kr = &fileKeyRing{fileName: filepath.Join(home, ".strongbox_keyring")}
 
 	if *flagGenKey != "" {
 		genKey(*flagGenKey)
@@ -103,10 +99,6 @@ func main() {
 	}
 	if *flagSmudge != "" {
 		smudge(os.Stdin, os.Stdout, *flagSmudge)
-		return
-	}
-	if *flagDiff != "" {
-		diff(*flagDiff)
 		return
 	}
 }
@@ -224,12 +216,12 @@ func clean(r io.Reader, w io.Writer, filename string) {
 		return
 	}
 	// File is plaintext and needs to be encrypted, get the key, fail on error
-	keyID, key, err := keyLoader(filename)
+	key, err := keyLoader(filename)
 	if err != nil {
 		log.Fatal(err)
 	}
 	// encrypt the file, fail on error
-	out, err := encrypt(in, key, keyID)
+	out, err := encrypt(in, key)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -256,25 +248,19 @@ func smudge(r io.Reader, w io.Writer, filename string) {
 		return
 	}
 
-	// try to get the key using the header, failing that, try to get the
-	// key using the filename
-	var key []byte
-	key, err = keyFromHeader(in)
+	key, err := keyLoader(filename)
 	if err != nil {
-		_, key, err = keyLoader(filename)
-		if err != nil {
-			// don't log error if its keyNotFound
-			switch err {
-			case errKeyNotFound:
-			default:
-				log.Println(err)
-			}
-			// Couldn't load the key, just copy as is and return
-			if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
-				log.Println(err)
-			}
-			return
+		// don't log error if its keyNotFound
+		switch err {
+		case errKeyNotFound:
+		default:
+			log.Println(err)
 		}
+		// Couldn't load the key, just copy as is and return
+		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
+			log.Println(err)
+		}
+		return
 	}
 
 	out, err := decrypt(in, key)
@@ -287,23 +273,7 @@ func smudge(r io.Reader, w io.Writer, filename string) {
 	}
 }
 
-// keyFromHeader looks through the file content, trying to get key-id value,
-// and look up the key in the keyring
-func keyFromHeader(in []byte) ([]byte, error) {
-	match := keyIDRegex.FindStringSubmatch(string(in))
-	if len(match) != 2 {
-		return []byte{}, errKeyIDMissingFromHeader
-	}
-	decodedKeyID, _ := decode([]byte(match[1]))
-	key, err := kr.Key(decodedKeyID)
-	//log.Printf("DEBUG: found key %s %e", encode(key), err)
-	if err != nil {
-		return []byte{}, err
-	}
-	return key, nil
-}
-
-func encrypt(b []byte, key, keyID []byte) ([]byte, error) {
+func encrypt(b, key []byte) ([]byte, error) {
 	b = compress(b)
 	out, err := siv.Encrypt(nil, key, b, nil)
 	if err != nil {
@@ -368,12 +338,13 @@ func decode(encoded []byte) ([]byte, error) {
 }
 
 func decrypt(enc []byte, priv []byte) ([]byte, error) {
-	// strip the prefix (both single line v0.1 and multiline v0.2)
-	ciphertext := prefixStripRegex.Find(enc)
-	if ciphertext == nil {
-		return nil, errors.New("Couldn't split strongbox prefix and ciphertext")
+	// strip prefix and any comment up to end of line
+	spl := bytes.SplitN(enc, []byte("\n"), 2)
+	if len(spl) != 2 {
+		return nil, errors.New("Couldn't split on end of line")
 	}
-	b64decoded, err := decode(ciphertext)
+	b64encoded := spl[1]
+	b64decoded, err := decode(b64encoded)
 	if err != nil {
 		return nil, err
 	}
@@ -385,24 +356,24 @@ func decrypt(enc []byte, priv []byte) ([]byte, error) {
 	return decrypted, nil
 }
 
-// keyPair returns public, private and error
-func keyPair(filename string) ([]byte, []byte, error) {
+// key returns private key and error
+func key(filename string) ([]byte, error) {
 	keyID, err := findKey(filename)
 	if err != nil {
-		return []byte{}, []byte{}, err
+		return []byte{}, err
 	}
 
 	err = kr.Load()
 	if err != nil {
-		return []byte{}, []byte{}, err
+		return []byte{}, err
 	}
 
 	key, err := kr.Key(keyID)
 	if err != nil {
-		return []byte{}, []byte{}, err
+		return []byte{}, err
 	}
 
-	return keyID, key, nil
+	return key, nil
 }
 
 func findKey(filename string) ([]byte, error) {

--- a/strongbox_test.go
+++ b/strongbox_test.go
@@ -51,8 +51,8 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testKeyLoader(string) ([]byte, []byte, error) {
-	return pub, priv, nil
+func testKeyLoader(string) ([]byte, error) {
+	return priv, nil
 }
 
 func TestMultipleClean(t *testing.T) {


### PR DESCRIPTION
Since adding a complicated header meant a lot of complications to use,
we decided to not proceed with it.

This is cleaning up all the remnants of code from that pice of work and
documenting the issue that was meant to be addressed.

Another small change is moving the `diff` function higher up to reduce number of syscalls when claling `strongbox -diff`:

```
# strongbox - current master

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 44.66    0.000272         272         1           write
 13.14    0.000080          20         4           clone
  9.36    0.000057          28         2           futex
  8.70    0.000053          53         1           readlinkat
  4.93    0.000030           7         4           read
  4.27    0.000026           8         3           openat
  2.79    0.000017           1        10           rt_sigprocmask
  2.63    0.000016           3         5         4 epoll_ctl
  2.13    0.000013           4         3           close
  1.97    0.000012          12         1           pipe2
  1.81    0.000011           3         3           fcntl
  1.48    0.000009           0        19           mmap
  1.48    0.000009           9         1           epoll_create1
  0.66    0.000004           4         1           getuid
  0.00    0.000000           0       114           rt_sigaction
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           uname
  0.00    0.000000           0         2           sigaltstack
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           gettid
  0.00    0.000000           0         1           sched_getaffinity
------ ----------- ----------- --------- --------- ------------------
100.00    0.000609           3       179         4 total
```

```
# strongbox with drive_home and diff moved

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ------------------
 34.22    0.000116         116         1           write
 21.83    0.000074          74         1           readlinkat
  7.96    0.000027           9         3         2 epoll_ctl
  7.08    0.000024          12         2           futex
  7.08    0.000024          12         2           openat
  6.19    0.000021           7         3           fcntl
  5.90    0.000020           6         3           read
  4.42    0.000015          15         1           pipe2
  2.65    0.000009           9         1           epoll_create1
  1.18    0.000004           2         2           uname
  0.88    0.000003           3         1         1 copy_file_range
  0.59    0.000002           1         2           close
  0.00    0.000000           0        19           mmap
  0.00    0.000000           0       114           rt_sigaction
  0.00    0.000000           0         8           rt_sigprocmask
  0.00    0.000000           0         3           clone
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         2           sigaltstack
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           gettid
  0.00    0.000000           0         1           sched_getaffinity
------ ----------- ----------- --------- --------- ------------------
100.00    0.000339           1       172         3 total
```