### PR TITLE
Added STRONGBOX_PATH for configuring config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ or as few files as you wish based on
 * [Security](#security)
 * [Testing](#testing)
 * [Known issues](#known-issues)
-	* [Clone file ordering](#clone-file-ordering)
-		* [Workaround](#workaround)
+  * [Clone file ordering](#clone-file-ordering)
+    * [Workaround](#workaround)
 
 <!-- vim-markdown-toc -->
 
@@ -34,7 +34,7 @@ You can obtain a binary from https://github.com/uw-labs/strongbox/releases
 Alternatively, assuming you have a working [Go](https://golang.org) installation, you can
 install via the following command:
 
-```bash
+```sh
 go install github.com/uw-labs/strongbox@v1.0.0
 ```
 
@@ -59,7 +59,14 @@ go install github.com/uw-labs/strongbox@v1.0.0
    ```
    This will add a new key to your `.strongbox_keyring`. By default, the
    keyring is created in the `$HOME` directory, but this location can be changed
-   by setting the `$STRONGBOX_HOME` environmental variable.
+   by setting the `$STRONGBOX_HOME` or `$STRONGBOX_PATH` environmental variable.
+
+   For example:
+
+   ```sh
+   $ STRONGBOX_HOME=/some/directory strongbox # saves to /some/directory/.strongbox_keyring
+   $ STRONGBOX_PATH=/some/directory/strongbox.yml strongbox # saves to /some/directory/strongbox.yml
+   ```
 
 4. Include a `.strongbox-keyid` file in your repository containing public key
    you want to use (typically by copying a public key from

--- a/strongbox.go
+++ b/strongbox.go
@@ -80,8 +80,7 @@ func main() {
 	}
 
 	// Set up keyring file name
-	home := deriveHome()
-	kr = &fileKeyRing{fileName: filepath.Join(home, ".strongbox_keyring")}
+	kr = &fileKeyRing{fileName: derivePath()}
 
 	if *flagGenKey != "" {
 		genKey(*flagGenKey)
@@ -121,9 +120,22 @@ func deriveHome() string {
 		return home
 	}
 
-	log.Fatal("Could not call os/user.Current() or find $STRONGBOX_HOME or $HOME. Please recompile with CGO enabled or set $STRONGBOX_HOME or $HOME")
+	vars := "$STRONGBOX_HOME, $STRONGBOX_PATH, or $HOME"
+	line1 := fmt.Sprintf("Could not call os/user.Current() or find %s", vars)
+	line2 := fmt.Sprintf("Please recompile with CGO enabled or set %s", vars)
+
+	log.Fatal(fmt.Sprintf("%s\n%s", line1, line2))
+
 	// not reached
 	return ""
+}
+
+func derivePath() string {
+	if path := os.Getenv("STRONGBOX_PATH"); path != "" {
+		return path
+	}
+
+	return filepath.Join(deriveHome(), ".strongbox_keyring")
 }
 
 func decryptCLI() {


### PR DESCRIPTION
I'm quite pedantic when it comes to file organisation so I'd prefer to configure the file name of the config file itself. Any pointers or improvements are welcome!

I've added a `STRONGBOX_PATH` which is derived from the `STRONGBOX_HOME`, defaulting to the defaults currently in place to avoid breaking anything. 