### PR TITLE
implemented recursive decryption via cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Test
         run: make test
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Test
         run: make test
       - name: Run GoReleaser

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '30 11 * * 3'
+    - cron: "30 11 * * 3"
 
 jobs:
   analyze:
@@ -32,40 +32,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ go install github.com/uw-labs/strongbox@v1.0.0
    directory structure until it finds the file.  This allows using different
    keys for different subdirectories within a repository.
 
+5. If strongbox keyring file is stored on different location `-keyring` can be used.
+   ie `strongbox [-keyring <keyring_file_path>] -gen-key key-name`
+
+6. Following commands can be used to manually decrypt file without gitOps
+   ```
+   # decrypt using default keyring file `$HOME/.strongbox_keyring`
+   strongbox -decrypt -recursive <path>
+
+   # decrypt using `keyring_file_path`
+   strongbox -keyring <keyring_file_path> -decrypt -recursive <path>
+
+   # decrypt using private key `<key>`
+   strongbox -key <key> -decrypt -recursive <path>
+
+   # decrypt single file with given key
+   strongbox -decrypt -key <key>
+   ```
 ## Existing project
 
 Strongbox uses [clean and smudge

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uw-labs/strongbox
 
-go 1.17
+go 1.19
 
 require (
 	github.com/jacobsa/crypto v0.0.0-20190317225127-9f44e2d11115

--- a/go.sum
+++ b/go.sum
@@ -17,11 +17,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/integration_tests/Dockerfile
+++ b/integration_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.19-alpine
 
 RUN apk --no-cache add git
 

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -6,4 +6,4 @@ go get -t .
 go install
 
 go get -t ./integration_tests/
-go test -v ./integration_tests/
+go test -v -tags=integration ./integration_tests/

--- a/keyring.go
+++ b/keyring.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -57,7 +56,7 @@ func (kr *fileKeyRing) Key(keyID []byte) ([]byte, error) {
 
 func (kr *fileKeyRing) Load() error {
 
-	bytes, err := ioutil.ReadFile(kr.fileName)
+	bytes, err := os.ReadFile(kr.fileName)
 	if err != nil {
 		return err
 	}
@@ -81,5 +80,5 @@ func (kr *fileKeyRing) Save() error {
 		}
 	}
 
-	return ioutil.WriteFile(kr.fileName, ser, 0600)
+	return os.WriteFile(kr.fileName, ser, 0600)
 }

--- a/strongbox.go
+++ b/strongbox.go
@@ -39,6 +39,7 @@ var (
 	flagGenKey    = flag.String("gen-key", "", "Generate a new key and add it to your strongbox keyring")
 	flagDecrypt   = flag.Bool("decrypt", false, "Decrypt single resource")
 	flagKey       = flag.String("key", "", "Private key to use to decrypt")
+	flagKeyRing   = flag.String("keyring", "", "strongbox keyring file path, if not set default '$HOME/.strongbox_keyring' will be used")
 
 	flagClean  = flag.String("clean", "", "intended to be called internally by git")
 	flagSmudge = flag.String("smudge", "", "intended to be called internally by git")
@@ -82,6 +83,15 @@ func main() {
 	// Set up keyring file name
 	home := deriveHome()
 	kr = &fileKeyRing{fileName: filepath.Join(home, ".strongbox_keyring")}
+
+	// if keyring flag is set replace default keyRing
+	if *flagKeyRing != "" {
+		kr = &fileKeyRing{fileName: *flagKeyRing}
+		// verify keyring is valid
+		if err := kr.Load(); err != nil {
+			log.Fatalf("unable to load keyring file:%s err:%s", *flagKeyRing, err)
+		}
+	}
 
 	if *flagGenKey != "" {
 		genKey(*flagGenKey)

--- a/strongbox.go
+++ b/strongbox.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -177,7 +176,7 @@ func decryptCLI() {
 	} else {
 		fn = flag.Arg(0)
 	}
-	fb, err := ioutil.ReadFile(fn)
+	fb, err := os.ReadFile(fn)
 	if err != nil {
 		log.Fatalf("Unable to read file to decrypt %v", err)
 	}
@@ -249,7 +248,7 @@ func diff(filename string) {
 
 func clean(r io.Reader, w io.Writer, filename string) {
 	// Read the file, fail on error
-	in, err := ioutil.ReadAll(r)
+	in, err := io.ReadAll(r)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -280,7 +279,7 @@ func clean(r io.Reader, w io.Writer, filename string) {
 
 // Called by git on `git checkout`
 func smudge(r io.Reader, w io.Writer, filename string) {
-	in, err := ioutil.ReadAll(r)
+	in, err := io.ReadAll(r)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -445,7 +444,7 @@ func decompress(b []byte) []byte {
 	if err != nil {
 		log.Fatal(err)
 	}
-	b, err = ioutil.ReadAll(zr)
+	b, err = io.ReadAll(zr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -474,7 +473,7 @@ func decrypt(enc []byte, priv []byte) ([]byte, error) {
 	// strip prefix and any comment up to end of line
 	spl := bytes.SplitN(enc, []byte("\n"), 2)
 	if len(spl) != 2 {
-		return nil, errors.New("Couldn't split on end of line")
+		return nil, errors.New("couldn't split on end of line")
 	}
 	b64encoded := spl[1]
 	b64decoded, err := decode(b64encoded)
@@ -527,7 +526,7 @@ func findKey(filename string) ([]byte, error) {
 }
 
 func readKey(filename string) ([]byte, error) {
-	fp, err := ioutil.ReadFile(filename)
+	fp, err := os.ReadFile(filename)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/strongbox.go
+++ b/strongbox.go
@@ -324,7 +324,7 @@ func smudge(r io.Reader, w io.Writer, filename string) {
 // otherwise it will find key based on file location
 // if error is generated in finding key or in decryption then it will continue with next file
 // function will only return early if it failed to read/write files
-func recursiveDecrypt(target string, key []byte) error {
+func recursiveDecrypt(target string, givenKey []byte) error {
 	var decErrors []string
 	err := filepath.WalkDir(target, func(path string, entry fs.DirEntry, err error) error {
 		// always return on error
@@ -358,6 +358,7 @@ func recursiveDecrypt(target string, key []byte) error {
 			return nil
 		}
 
+		key := givenKey
 		if len(key) == 0 {
 			key, err = keyLoader(path)
 			if err != nil {


### PR DESCRIPTION
This PR is to implement recursive decryption without git filters

adding 2 new flags

`-keyring <keyring_file_path>` :
if set, strongbox will use `keyring_file_path` as keyring instead of the default.
this flag can be used with other flags like with `git-config` it will write a new key to this location.

`-recursive`:
flag to decrypt all encrypted files in the given location. This flag must be used with the `-decrypt` flag
it supports `keyring` and `key` flags but both are optional.

```
# decrypt using default keyring file `$HOME/.strongbox_keyring`
strongbox -decrypt -recursive <path>

# decrypt using `keyring_file_path`
strongbox -keyring <keyring_file_path> -decrypt -recursive <path>

# decrypt using private key `<key>`
strongbox -key <key> -decrypt -recursive <path>

# existing decrypt command for single file is not changed.
# decrypt single file with given key
strongbox -decrypt -key <key>
```

Use case:
1) ability to decrypt strongbox encrypted files without `git`
2) ability to decrypt file after cloning repo without valid keyring, now one can run recursive decrypt after adding valid private key to keyring