### PR TITLE
Do not build windows or 368 arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,18 +4,14 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - windows
       - darwin
       - linux
       - freebsd
     goarch:
-      - 386
       - amd64
       - arm
       - arm64
     ignore:
-      - goos: darwin
-        goarch: "386"
       - goos: freebsd
         goarch: arm64
 


### PR DESCRIPTION
We don't run or support Strongbox on Windows and 386 arch, building for
it invites support we cannot provide.
