### PR TITLE
Fix module import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/uw-labs/strongbox
+module github.com/uw-labs/strongbox/v2
 
 go 1.21
 


### PR DESCRIPTION
I was trying to install this and running into errors:

    $ go install github.com/uw-labs/strongbox@v2.0.0-RC4
    go: github.com/uw-labs/strongbox@v2.0.0-RC4: github.com/uw-labs/strongbox@v2.0.0-RC4: invalid version: module contains a go.mod file, so module path must match major version ("github.com/uw-labs/strongbox/v2")
    $ go install github.com/uw-labs/strongbox/v2@v2.0.0-RC4
    go: github.com/uw-labs/strongbox/v2@v2.0.0-RC4: github.com/uw-labs/strongbox@v2.0.0-RC4: invalid version: module contains a go.mod file, so module path must match major version ("github.com/uw-labs/strongbox/v2")

Resolve these by adding the major version to the module path