### PR TITLE
merge driver2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If both identity / key files are present in the same directory,
    For example:
 
    ```
-   secrets/* filter=strongbox diff=strongbox
+   secrets/* filter=strongbox diff=strongbox merge=strongbox
    ```
 
 3. Generate a key to use for the encryption, for example:

--- a/strongbox.go
+++ b/strongbox.go
@@ -190,7 +190,7 @@ func decryptCLI() {
 		log.Fatalf("Unable to decrypt %v", err)
 	}
 	fmt.Printf("%s", out)
-}	
+}
 
 func gitConfig() {
 	args := [][]string{

--- a/strongbox.go
+++ b/strongbox.go
@@ -190,7 +190,7 @@ func decryptCLI() {
 		log.Fatalf("Unable to decrypt %v", err)
 	}
 	fmt.Printf("%s", out)
-}
+}	
 
 func gitConfig() {
 	args := [][]string{
@@ -220,7 +220,7 @@ git merge-file \
 	"$other_file" \
 	> "$5"
 `
-	if err := os.WriteFile(filepath.Join(os.Getenv("HOME"), "strongbox_merge_driver.sh"), []byte(mergeDriver), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(deriveHome(), "strongbox_merge_driver.sh"), []byte(mergeDriver), 0755); err != nil {
 		log.Fatalf("failed to write merge driver script %v", err)
 	}
 	for _, command := range args {

--- a/strongbox.go
+++ b/strongbox.go
@@ -334,6 +334,8 @@ func smudge(r io.Reader, w io.Writer, filename string) {
 }
 
 func mergeFile() {
+	// https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver
+	//
 	// The merge driver is expected to leave the result of the merge in the file
 	// named with %A by overwriting it, and exit with zero status if it managed to
 	// merge them cleanly, or non-zero if there were conflicts. When the driver

--- a/strongbox_test.go
+++ b/strongbox_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	HOME           = os.Getenv("HOME")
-	defaultRepoDir = HOME + "/test-proj/"
+	HOME           = deriveHome()
+	defaultRepoDir = "/tmp/test-proj/"
 	defaultBranch  = "main"
 )
 

--- a/strongbox_test.go
+++ b/strongbox_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	HOME = os.Getenv("HOME")
+	HOME           = os.Getenv("HOME")
 	defaultRepoDir = HOME + "/test-proj/"
-	defaultBranch = "main"
+	defaultBranch  = "main"
 )
 
 func command(dir, name string, arg ...string) (out []byte, err error) {
@@ -138,31 +138,30 @@ func TestMergeDriverMerge(t *testing.T) {
 	_, keyID := keysFromKR(t, "test00")
 	ga := "secrets/* filter=strongbox diff=strongbox merge=strongbox"
 
-	assertReadFile(t, deriveHome() + "/strongbox_merge_driver.sh")
 	assertWriteFile(t, repoDir+"/.gitattributes", []byte(ga), 0644)
 	assertWriteFile(t, repoDir+"/.strongbox-keyid", []byte(keyID), 0644)
 	assertCommand(t, repoDir, "mkdir", "-p", secDir)
 	assertWriteFile(t, repoDir+secFilePath, []byte(secVal), 0644)
 	assertCommand(t, repoDir, "git", "add", ".")
 	assertCommand(t, repoDir, "git", "commit", "-m", "\"TestMergeDriverMerge\"")
-	
+
 	branches := []string{"temp1", "temp2"}
 	for i, branch := range branches {
 		if i != 0 {
 			assertCommand(t, repoDir, "git", "checkout", defaultBranch)
 		}
 		assertCommand(t, repoDir, "git", "checkout", "-b", branch)
-		assertWriteFile(t, repoDir+secFilePath, []byte(secVal + branch), 0644)
+		assertWriteFile(t, repoDir+secFilePath, []byte(secVal+branch), 0644)
 		assertCommand(t, repoDir, "git", "add", ".")
-		assertCommand(t, repoDir, "git", "commit", "-m", "\"TestMergeDiff "+ branch + "\"")
-		if i == len(branches) - 1 {
+		assertCommand(t, repoDir, "git", "commit", "-m", "\"TestMergeDiff "+branch+"\"")
+		if i == len(branches)-1 {
 			command(repoDir, "git", "merge", "temp1")
 		}
 	}
 
 	out, _ := command(repoDir, "cat", secFilePath)
 	assert.NotContains(t, string(out), "STRONGBOX ENCRYPTED RESOURCE")
-	assert.Contains(t, string(out), "<<<<<<< HEAD\n" + secVal + branches[1] + "\n=======\n" + secVal + branches[0] + "\n>>>>>>> " + branches[0] + "\n")
+	assert.Contains(t, string(out), "<<<<<<< HEAD\n"+secVal+branches[1]+"\n=======\n"+secVal+branches[0]+"\n>>>>>>> "+branches[0]+"\n")
 	command(repoDir, "git", "merge", "--abort")
 	command(repoDir, "git", "checkout", defaultBranch)
 	for _, branch := range branches {
@@ -180,13 +179,12 @@ func TestMergeDriverRebase(t *testing.T) {
 	_, keyID := keysFromKR(t, "test00")
 	ga := "secrets/* filter=strongbox diff=strongbox merge=strongbox"
 
-	assertReadFile(t, deriveHome() + "/strongbox_merge_driver.sh")
 	assertWriteFile(t, repoDir+"/.gitattributes", []byte(ga), 0644)
 	assertWriteFile(t, repoDir+"/.strongbox-keyid", []byte(keyID), 0644)
 	assertCommand(t, repoDir, "mkdir", "-p", secDir)
 	assertWriteFile(t, repoDir+secFilePath, []byte(secVal), 0644)
 	assertCommand(t, repoDir, "git", "add", ".")
-	assertCommand(t, repoDir, "git", "commit", "-m", "\"" + commitMsg + "\"")
+	assertCommand(t, repoDir, "git", "commit", "-m", "\""+commitMsg+"\"")
 
 	commitHash := ""
 	branches := []string{"temp1", "temp2"}
@@ -196,11 +194,11 @@ func TestMergeDriverRebase(t *testing.T) {
 			assertCommand(t, repoDir, "git", "checkout", defaultBranch)
 		}
 		assertCommand(t, repoDir, "git", "checkout", "-b", branch)
-		assertWriteFile(t, repoDir+secFilePath, []byte(secVal + branch), 0644)
+		assertWriteFile(t, repoDir+secFilePath, []byte(secVal+branch), 0644)
 		assertCommand(t, repoDir, "git", "add", ".")
-		assertCommand(t, repoDir, "git", "commit", "-m", "\"" + branchCommitMsg + "\"")
-		if i == len(branches) - 1 {
-			assertCommand(t, repoDir, "git", "checkout", branches[i - 1])
+		assertCommand(t, repoDir, "git", "commit", "-m", "\""+branchCommitMsg+"\"")
+		if i == len(branches)-1 {
+			assertCommand(t, repoDir, "git", "checkout", branches[i-1])
 			commitHashBytes := assertCommand(t, repoDir, "git", "rev-parse", "--short", "HEAD")
 			commitHash = strings.TrimSuffix(string(commitHashBytes), "\n")
 			fmt.Println(commitHash)
@@ -210,7 +208,7 @@ func TestMergeDriverRebase(t *testing.T) {
 
 	out, _ := command(repoDir, "cat", secFilePath)
 	assert.NotContains(t, string(out), "STRONGBOX ENCRYPTED RESOURCE")
-	assert.Contains(t, string(out), "<<<<<<< HEAD\n" + secVal + branches[1] + "\n=======\n" + secVal + branches[0] + "\n>>>>>>> " + commitHash + " (\"" + commitMsg + " " + branches[0] + "\")" + "\n")
+	assert.Contains(t, string(out), "<<<<<<< HEAD\n"+secVal+branches[1]+"\n=======\n"+secVal+branches[0]+"\n>>>>>>> "+commitHash+" (\""+commitMsg+" "+branches[0]+"\")"+"\n")
 	command(repoDir, "git", "rebase", "--abort")
 	command(repoDir, "git", "checkout", defaultBranch)
 	for _, branch := range branches {
@@ -434,4 +432,3 @@ func TestAgeSimulateDeterministic(t *testing.T) {
 
 	assert.NotContains(t, string(status), "age/secrets/secret", "secret file showing up in diff")
 }
-


### PR DESCRIPTION
Allow the use of Git's merge driver to decrypt conflicting files and present plaintext in the conflicting merge file.