### PR TITLE
Allow local testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,3 +33,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: test
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 strongbox
+# strongbox binary built for integration tests
+/strongbox-test-bin

--- a/strongbox_local_test.go
+++ b/strongbox_local_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const _STRONGBOX_TEST_BINARY = "strongbox-test-bin"
+var binaryBuilt = false
+
+func ensureStrongboxBuilt(t *testing.T) {
+	if !binaryBuilt {
+		// build the binary once per test run
+		_, err := runCmd("go", "build", "-o", _STRONGBOX_TEST_BINARY, ".")
+		require.NoError(t, err)
+		binaryBuilt = true
+	}
+}
+
+func mustRunGitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := runGitCmd(dir, args...)
+	require.NoError(t, err)
+	return out
+}
+
+func runGitCmd(dir string, args ...string) (string, error) {
+	args = append([]string{"-C", dir}, args...)
+	return runCmd("git", args...)
+}
+
+func runCmd(name string, args ...string) (string, error) {
+	var stdout strings.Builder
+	var stderr strings.Builder
+
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), fmt.Errorf(
+			"running '%s' failed: %w\nstderr: %s",
+			strings.Join(cmd.Args, " "),
+			err,
+			stderr.String(),
+		)
+	}
+
+	return stdout.String(), nil
+}
+
+func configureGit(t *testing.T, repoDir string) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// pass a rooted path (and not just ./file) so we can run it from worktrees
+	testBinPath := filepath.Join(cwd, _STRONGBOX_TEST_BINARY)
+
+	// avoid reading any configuration files outside this repo
+	// https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGGLOBALcode
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	// tell git to use the config file in the worktree
+	// https://git-scm.com/docs/git-worktree#_configuration_file
+	mustRunGitCmd(t, ".", "config", "set", "--local", "extensions.worktreeConfig", "true")
+	// config is bare, so we need some basic things set
+	mustRunGitCmd(t, repoDir, "config", "set", "--worktree", "user.name", "strongbox-tester")
+	mustRunGitCmd(
+		t,
+		repoDir,
+		"config",
+		"set",
+		"--worktree",
+		"user.email",
+		"strongbox-tester@example.com",
+	)
+
+	// setup strongbox
+	mustRunGitCmd(
+		t,
+		repoDir,
+		"config",
+		"set",
+		"--worktree",
+		"filter.strongbox.clean",
+		testBinPath+" -clean %f",
+	)
+	mustRunGitCmd(
+		t,
+		repoDir,
+		"config",
+		"set",
+		"--worktree",
+		"filter.strongbox.smudge",
+		testBinPath+" -smudge %f",
+	)
+	mustRunGitCmd(t, repoDir, "config", "set", "--worktree", "filter.strongbox.required", "true")
+	mustRunGitCmd(
+		t,
+		repoDir,
+		"config",
+		"set",
+		"--worktree",
+		"diff.strongbox.textconv",
+		testBinPath+" -diff",
+	)
+}
+
+func configureStrongbox(t *testing.T, repoDir string) {
+	// tell strongbox to use our testing keys
+	t.Setenv("STRONGBOX_HOME", filepath.Join(repoDir, "testdata"))
+}
+
+func setupWorkTree(t *testing.T, name string) string {
+	t.Helper()
+	worktreePath := filepath.Join(t.TempDir(), name)
+
+	mustRunGitCmd(t, ".", "worktree", "add", "--quiet", "--detach", worktreePath)
+	t.Cleanup(func() {
+		// practically, this shouldn't error. But even if it does, it's not
+		// a big deal: the TempDir is cleaned up at the end of testing anyway, and
+		// git eventually stops tracking worktrees on paths that don't exist
+		if _, err := runGitCmd(".", "worktree", "remove", "--force", worktreePath); err != nil {
+			t.Logf(
+				"failed to remove worktree %s (you may want to manually remove it): %v",
+				worktreePath,
+				err,
+			)
+		}
+	})
+
+	configureGit(t, worktreePath)
+	configureStrongbox(t, worktreePath)
+
+	return worktreePath
+}
+
+func TestGitIntegration_Filtering(t *testing.T) {
+	ensureStrongboxBuilt(t)
+	repoDir := setupWorkTree(t, t.Name())
+
+	rawContent := "t0ps3cret\n"
+	expectedEncryptedPrefix := "-----BEGIN AGE ENCRYPTED FILE-----"
+	secretPath := filepath.Join("testdata", "secret-"+t.Name()+".txt")
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(repoDir, secretPath),
+			[]byte(rawContent),
+			0o400,
+		),
+	)
+	mustRunGitCmd(t, repoDir, "add", secretPath)
+
+	diff, err := runGitCmd(repoDir, "diff", "--exit-code", secretPath)
+	require.NoError(
+		t,
+		err,
+		"git detected a diff after adding the file (probably an issue with smudging and cleaning):\n%s",
+		diff,
+	)
+	mustRunGitCmd(t, repoDir, "commit", "--message", "Add a secret")
+
+	worktreeContent, err := os.ReadFile(filepath.Join(repoDir, secretPath))
+	require.NoError(t, err)
+	require.Equal(t, rawContent, string(worktreeContent), "file in worktree should be decrypted")
+	require.Equal(
+		t,
+		expectedEncryptedPrefix,
+		mustRunGitCmd(t, repoDir, "show", "HEAD:"+secretPath)[:len(expectedEncryptedPrefix)],
+		"checked-in file should be encrypted",
+	)
+}

--- a/testdata/.gitattributes
+++ b/testdata/.gitattributes
@@ -1,0 +1,1 @@
+/secret*.txt diff=strongbox filter=strongbox

--- a/testdata/.strongbox_identity
+++ b/testdata/.strongbox_identity
@@ -1,0 +1,3 @@
+# description: test-key
+# public key: age1q4tfxy9645k4mtzk0v6w5lgn5m9dav0y4wy0fk0crxxve7q08utsxa8wpl
+AGE-SECRET-KEY-1EMJF0QD9M8RZ5XKRJVSZF6U70VGZCZDKA5RCQNHFQR2F3PUAPMRQ7FXA9H

--- a/testdata/.strongbox_recipient
+++ b/testdata/.strongbox_recipient
@@ -1,0 +1,1 @@
+age1q4tfxy9645k4mtzk0v6w5lgn5m9dav0y4wy0fk0crxxve7q08utsxa8wpl


### PR DESCRIPTION
- Move integration testing to run locally

    And not in Docker. This patch is to prove things work, so I've just
    moved one test across (though most of the changes are in test setup that
    can be re-used across tests). If this gets tractions, more tests could
    be moved across. Reasons for this approach:

    * Simplicity: tests have no external requirements besides `git`
    * Debugability: running locally you can spin up a debugger (or just
      sleep in tests) and inspect the running environment. This is possible
      with Docker, but more of a hassle
    * Reproducibility: tests are decoupled from the user's environment, so
      failures should be reproducible

    This is achieved via:

    * Using git's worktree's[1] to run things like `git commit` without
      modifying the working repo
    * Having the tests build a strongbox binary that we can then configure
      `git` with (built once per run)
    * Adding some test setup with actual keys etc. rather than relying on the
      user having keys define

    For posterity, the commands to setup the keys etc

        go run . -identity-file ./testdata/.strongbox_identity -gen-identity test-key
        grep --only-matching --perl-regexp '(?<=# public key: ).*' ./testdata/.strongbox_identity > ./testdata/.strongbox_recipient

    Link: https://git-scm.com/docs/git-worktree [1]

- Add run of local tests in GitHub