### PR TITLE
log decryption errors

### DIFF
--- a/age.go
+++ b/age.go
@@ -95,6 +95,7 @@ func ageDecrypt(w io.Writer, in []byte) {
 	defer identityFile.Close()
 	identities, err := age.ParseIdentities(identityFile)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse identity file: %v\n", err)
 		// could not parse identity file, copy as is and return
 		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
 			log.Println(err)

--- a/age.go
+++ b/age.go
@@ -106,7 +106,6 @@ func ageDecrypt(w io.Writer, in []byte) {
 	armorReader := armor.NewReader(bytes.NewReader(in))
 	ar, err := age.Decrypt(armorReader, identities...)
 	if err != nil {
-		log.Println("failed to decrypt:", err)
 		// couldn't find the key, copy as is and return
 		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
 			log.Println(err)

--- a/age.go
+++ b/age.go
@@ -95,7 +95,7 @@ func ageDecrypt(w io.Writer, in []byte) {
 	defer identityFile.Close()
 	identities, err := age.ParseIdentities(identityFile)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to parse identity file: %v\n", err)
+		log.Println("failed to parse identity file:", err)
 		// could not parse identity file, copy as is and return
 		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
 			log.Println(err)

--- a/age.go
+++ b/age.go
@@ -86,6 +86,7 @@ func ageEncrypt(w io.Writer, r []age.Recipient, in []byte, f string) {
 func ageDecrypt(w io.Writer, in []byte) {
 	identityFile, err := os.Open(identityFilename)
 	if err != nil {
+		log.Println("failed to open identity file:", err)
 		// identity file doesn't exist, copy as is and return
 		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
 			log.Println(err)
@@ -105,6 +106,7 @@ func ageDecrypt(w io.Writer, in []byte) {
 	armorReader := armor.NewReader(bytes.NewReader(in))
 	ar, err := age.Decrypt(armorReader, identities...)
 	if err != nil {
+		log.Println("failed to decrypt:", err)
 		// couldn't find the key, copy as is and return
 		if _, err = io.Copy(w, bytes.NewReader(in)); err != nil {
 			log.Println(err)


### PR DESCRIPTION
Before this, it was hard to debug decryption issues, as the errors were disregarded.

It keeps the backwards compatibility, as stdout is not affected. The logs are printed to stderr.
